### PR TITLE
Add HPA for my-ruby-app

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-ruby-app-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-ruby-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50


### PR DESCRIPTION
Implemented Horizontal Pod Autoscaler (HPA) for my-ruby-app
Min replicas: 2, Max replicas: 10
CPU target utilization: 50%